### PR TITLE
README: specify OpenSSL in system requirements, move the section upwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,9 @@ nail provides detailed error messages for common issues:
 - **Operating System**: Linux (Ubuntu 24.04+ recommended), macOS, Windows
 - **Memory**: 4GB+ RAM (8GB+ recommended for large datasets)
 - **Storage**: SSD recommended for large file operations
-- **Dependencies**: None (statically linked binary)
+- **Dependencies**:
+  - Darwin: none
+  - Linux: `pkg-config` and `openssl`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ A high-performance command-line utility for working with Parquet files, built wi
 - **Flexible output**: console display or file output in multiple formats
 - **Production-ready** with robust error handling and verbose logging
 
+## System Requirements
+
+- **Operating System**: Linux (Ubuntu 24.04+ recommended), macOS, Windows
+- **Memory**: 4GB+ RAM (8GB+ recommended for large datasets)
+- **Storage**: SSD recommended for large file operations
+- **Dependencies**:
+  - Darwin: none
+  - Linux: `pkg-config` and `openssl` (package names might vary depending on your distro)
+
 ## Installation
 
 ```
@@ -954,15 +963,6 @@ nail provides detailed error messages for common issues:
 - **Schema mismatches**: Detailed information about incompatible schemas in merge/append operations
 - **Invalid expressions**: Specific feedback on malformed filter conditions or column patterns
 - **Memory issues**: Graceful handling of large datasets with appropriate error messages
-
-## System Requirements
-
-- **Operating System**: Linux (Ubuntu 24.04+ recommended), macOS, Windows
-- **Memory**: 4GB+ RAM (8GB+ recommended for large datasets)
-- **Storage**: SSD recommended for large file operations
-- **Dependencies**:
-  - Darwin: none
-  - Linux: `pkg-config` and `openssl`
 
 ## License
 


### PR DESCRIPTION
Sandboxed Linux build fails without OpenSSL. Moving system requirements up would be useful for downstream users and maintainers